### PR TITLE
fix for exporting cell images

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -2029,7 +2029,7 @@ namespace ServerGridEditor
             if (currentProject == null)
                 return;
 
-            saveFileDialog.Filter = "png files (*.png)|*.png";
+            saveFileDialog.Filter = currentProject.exportPngs ? "png files (*.png)|*.png" : "jpg files (*.jpg)|*.jpg";
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
             {
                 ExportCellImages(saveFileDialog.FileName);


### PR DESCRIPTION
This addresses an issue where even if you leave the box unchecked for exporting PNGs the CellImages are still exported with the PNG file extension