### PR TITLE
Fix missing space in button label

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.Designer.cs
@@ -179,7 +179,7 @@
             this.createProjBtn.Name = "createProjBtn";
             this.createProjBtn.Size = new System.Drawing.Size(239, 84);
             this.createProjBtn.TabIndex = 19;
-            this.createProjBtn.Text = "CreateProject";
+            this.createProjBtn.Text = "Create Project";
             this.createProjBtn.UseVisualStyleBackColor = true;
             this.createProjBtn.Click += new System.EventHandler(this.createProjBtn_Click);
             // 


### PR DESCRIPTION
The `createProjBtn` control in `MainForm.cs` has its `Text` property set to `CreateProject` - I think the intent was for it to read `Create Project`.