### PR TITLE
Target .NET Framework 4.7.2

### DIFF
--- a/ServerGridEditor.exe.config
+++ b/ServerGridEditor.exe.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Src/AtlasGridDataLibrary/AtlasGridDataLibrary.csproj
+++ b/Src/AtlasGridDataLibrary/AtlasGridDataLibrary.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AtlasGridDataLibrary</RootNamespace>
     <AssemblyName>AtlasGridDataLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Src/ServerGridEditor/App.config
+++ b/Src/ServerGridEditor/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Src/ServerGridEditor/Properties/Resources.Designer.cs
+++ b/Src/ServerGridEditor/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ServerGridEditor.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Src/ServerGridEditor/Properties/Settings.Designer.cs
+++ b/Src/ServerGridEditor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ServerGridEditor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Src/ServerGridEditor/ServerGridEditor.csproj
+++ b/Src/ServerGridEditor/ServerGridEditor.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ServerGridEditor</RootNamespace>
     <AssemblyName>ServerGridEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
Currently, the two projects in the solution target .NET Framework 4.5.1. This means downloading [a somewhat hard to find .NET Targeting Pack](https://www.microsoft.com/en-us/download/details.aspx?id=40772) and also limits future compatibility with respect to potentially changing to .NET Core (the v3 preview supports WinForms, so down the road it's not out of the question even without a shift to another UI library).

I don't know what tooling you have to support on the backend, so if you are targeting 4.5.1 for a good reason just close this - but if it's all the same to you, it'll make contributing easier for newer C# devs if you target a version of .NET that is installed with VS2017 Community by default.