### PR TITLE
Fix commented-out assignment resulting in unexpected export behavior

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -2137,6 +2137,7 @@ namespace ServerGridEditor
                     if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
                     {
                         //editorConfig.LastOpenedFolder = exportDir = fbd.SelectedPath;
+                        exportDir = fbd.SelectedPath;
                         SaveConfig();
                     }
                     else


### PR DESCRIPTION
In my testing, it seems like the directory you select when clicking "Local Export All" does not influence where the editor creates files - regardless of directory chosen, it always exports to `./Export` - looking at the code the culprit is pretty obvious:

```cs
//editorConfig.LastOpenedFolder = exportDir = fbd.SelectedPath;
```

I assume that `Config` lost its `LastOpenedFolder` property, this line was commented to fix the build, and the `exportDir = fbd.SelectedPath` was a casualty of war. If so, this should fix things until further refactoring can be performed.