### PR TITLE
Fix NullReferenceException, guard against DirectoryNotFoundException

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.Designer.cs
@@ -388,6 +388,7 @@
             // 
             // testAllServersWithoutDataClearToolStripMenuItem
             // 
+            this.testAllServersWithoutDataClearToolStripMenuItem.Enabled = false;
             this.testAllServersWithoutDataClearToolStripMenuItem.Name = "testAllServersWithoutDataClearToolStripMenuItem";
             this.testAllServersWithoutDataClearToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.testAllServersWithoutDataClearToolStripMenuItem.Text = "Test All Servers (Without Data clear)";

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -180,15 +180,14 @@ namespace ServerGridEditor
 
         public void EnableProjectMenuItems()
         {
-            var enabled = true;
-            editToolStripMenuItem.Enabled = enabled;
-            saveToolStripMenuItem.Enabled = enabled;
-            mapImageToolStripMenuItem.Enabled = enabled;
-            slippyMapToolStripMenuItem.Enabled = enabled;
-            cellImagesToolStripMenuItem.Enabled = enabled;
-            localExportToolStripMenuItem.Enabled = enabled;
-            editServerTemplatesToolStripMenuItem.Enabled = enabled;
-            testAllServersWithoutDataClearToolStripMenuItem.Enabled = enabled;
+            editToolStripMenuItem.Enabled = true;
+            saveToolStripMenuItem.Enabled = true;
+            mapImageToolStripMenuItem.Enabled = true;
+            slippyMapToolStripMenuItem.Enabled = true;
+            cellImagesToolStripMenuItem.Enabled = true;
+            localExportToolStripMenuItem.Enabled = true;
+            editServerTemplatesToolStripMenuItem.Enabled = true;
+            testAllServersWithoutDataClearToolStripMenuItem.Enabled = true;
         }
 
         public void SetScaleTxt(float unrealUnits)

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -2005,6 +2005,13 @@ namespace ServerGridEditor
                 return;
 
             string jsonFileName = MainForm.gameDir + "/" + MainForm.actualJsonFile;
+            var enclosingDirectory = Path.GetDirectoryName(jsonFileName);
+            if (!Directory.Exists(enclosingDirectory))
+            {
+                MessageBox.Show($"Asked to create {MainForm.actualJsonFile} in non-existent directory:\n{enclosingDirectory}", "Test Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
             File.WriteAllText(jsonFileName, currentProject.Serialize(this));
 
             int i = 0;

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -263,17 +263,19 @@ namespace ServerGridEditor
 
         public void DrawMapToGraphics(ref Graphics g, bool cull = false, bool ignoreTranslation = false, bool forExport = false)
         {
+            var isProjectPresent = currentProject != null;
 
-            if (currentProject == null)
+            editToolStripMenuItem.Enabled = isProjectPresent;
+            saveToolStripMenuItem.Enabled = isProjectPresent;
+            mapImageToolStripMenuItem.Enabled = isProjectPresent;
+            slippyMapToolStripMenuItem.Enabled = isProjectPresent;
+            cellImagesToolStripMenuItem.Enabled = isProjectPresent;
+            localExportToolStripMenuItem.Enabled = isProjectPresent;
+            editServerTemplatesToolStripMenuItem.Enabled = isProjectPresent;
+            testAllServersWithoutDataClearToolStripMenuItem.Enabled = isProjectPresent;
+
+            if (!isProjectPresent)
                 return;
-
-            editToolStripMenuItem.Enabled = true;
-            saveToolStripMenuItem.Enabled = true;
-            mapImageToolStripMenuItem.Enabled = true;
-            editServerTemplatesToolStripMenuItem.Enabled = true;
-            cellImagesToolStripMenuItem.Enabled = true;
-            slippyMapToolStripMenuItem.Enabled = true;
-            localExportToolStripMenuItem.Enabled = true;
 
             UpdateScrollBars();
 

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -178,6 +178,19 @@ namespace ServerGridEditor
             createProjBtn.Visible = !isVisible;
         }
 
+        public void EnableProjectMenuItems()
+        {
+            var enabled = true;
+            editToolStripMenuItem.Enabled = enabled;
+            saveToolStripMenuItem.Enabled = enabled;
+            mapImageToolStripMenuItem.Enabled = enabled;
+            slippyMapToolStripMenuItem.Enabled = enabled;
+            cellImagesToolStripMenuItem.Enabled = enabled;
+            localExportToolStripMenuItem.Enabled = enabled;
+            editServerTemplatesToolStripMenuItem.Enabled = enabled;
+            testAllServersWithoutDataClearToolStripMenuItem.Enabled = enabled;
+        }
+
         public void SetScaleTxt(float unrealUnits)
         {
             scaleLbl.Text = "1 pixel = " + unrealUnits + " unreal units";
@@ -263,18 +276,7 @@ namespace ServerGridEditor
 
         public void DrawMapToGraphics(ref Graphics g, bool cull = false, bool ignoreTranslation = false, bool forExport = false)
         {
-            var isProjectPresent = currentProject != null;
-
-            editToolStripMenuItem.Enabled = isProjectPresent;
-            saveToolStripMenuItem.Enabled = isProjectPresent;
-            mapImageToolStripMenuItem.Enabled = isProjectPresent;
-            slippyMapToolStripMenuItem.Enabled = isProjectPresent;
-            cellImagesToolStripMenuItem.Enabled = isProjectPresent;
-            localExportToolStripMenuItem.Enabled = isProjectPresent;
-            editServerTemplatesToolStripMenuItem.Enabled = isProjectPresent;
-            testAllServersWithoutDataClearToolStripMenuItem.Enabled = isProjectPresent;
-
-            if (!isProjectPresent)
+            if (currentProject == null)
                 return;
 
             UpdateScrollBars();
@@ -1637,6 +1639,7 @@ namespace ServerGridEditor
 
                 if (loadedProj.successfullyLoaded)
                 {
+                    EnableProjectMenuItems();
                     actualJsonFile = openFileDialog.SafeFileName;
                     currentProject = loadedProj;
                     SetScaleTxt(1 / currentProject.coordsScaling);

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -2001,16 +2001,18 @@ namespace ServerGridEditor
 
         void TestAllServers(bool clearSaveData = false)
         {
+            if (currentProject == null)
+                return;
+
             string jsonFileName = MainForm.gameDir + "/" + MainForm.actualJsonFile;
             File.WriteAllText(jsonFileName, currentProject.Serialize(this));
 
             int i = 0;
-            if (currentProject != null)
-                foreach (Server server in currentProject.servers)
-                {
-                    ProcessStartInfo serverStartInfo, clientStartInfo;
-                    server.LaunchPreview(out serverStartInfo, out clientStartInfo, false, clearSaveData, false, ++i);
-                }
+            foreach (Server server in currentProject.servers)
+            {
+                ProcessStartInfo serverStartInfo, clientStartInfo;
+                server.LaunchPreview(out serverStartInfo, out clientStartInfo, false, clearSaveData, false, ++i);
+            }
         }
 
         private void editSpawnerTemplatesToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
This PR makes the following changes:

 * At app startup, "Test All Servers Without Data Clear" is now *disabled* rather than *enabled* - this prevents a NullReferenceException from occuring if the menu item is clicked before loading a project
 * Menu items that require a project are only enabled when a project is successfully loaded, not during `DrawMapToGraphics()`
* Guard against a possible NullReferenceException if currentProject is somehow null when trying to test all servers
* Guard against a possible DirectoryNotFoundException if `../../Projects/ShooterGame` does not exist when trying to test all servers - handle this by calling `MessageBox.Show()`