### PR TITLE
Add menu item that removes invalid ship paths

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.Designer.cs
@@ -92,6 +92,7 @@
             this.foregroundScaleBox = new System.Windows.Forms.NumericUpDown();
             this.label5 = new System.Windows.Forms.Label();
             this.atlasLocation = new System.Windows.Forms.Label();
+            this.cullInvalidPathsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tileScaleBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.foregroundScaleBox)).BeginInit();
@@ -280,7 +281,8 @@
             this.editAllDiscoveryZonesToolStripMenuItem,
             this.editSpawnPointsToolStripMenuItem,
             this.editServerTemplatesToolStripMenuItem,
-            this.editLocksToolStripMenuItem});
+            this.editLocksToolStripMenuItem,
+            this.cullInvalidPathsToolStripMenuItem});
             this.editToolStripMenuItem1.Name = "editToolStripMenuItem1";
             this.editToolStripMenuItem1.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem1.Text = "Edit";
@@ -759,6 +761,13 @@
             this.atlasLocation.TabIndex = 36;
             this.atlasLocation.Text = "Atlas Location";
             // 
+            // cullInvalidPathsToolStripMenuItem
+            // 
+            this.cullInvalidPathsToolStripMenuItem.Name = "cullInvalidPathsToolStripMenuItem";
+            this.cullInvalidPathsToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.cullInvalidPathsToolStripMenuItem.Text = "Cull Invalid Paths";
+            this.cullInvalidPathsToolStripMenuItem.Click += new System.EventHandler(this.cullInvalidPathsToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -886,6 +895,7 @@
         private System.Windows.Forms.ToolStripMenuItem editServerTemplatesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editLocksToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem cullInvalidPathsToolStripMenuItem;
     }
 }
 

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -2343,6 +2343,45 @@ namespace ServerGridEditor
             var editForm = new EditAllLocksForm(this);
             editForm.ShowDialog();
         }
+
+        private void cullInvalidPathsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (currentProject == null)
+                return;
+
+            // hold on to the count of culled paths for display purposes
+            var invalidCount = 0;
+
+            // determine the maximum X and Y coordinate that would be valid for this grid
+            var maxWidth = currentProject.cellSize * currentProject.numOfCellsX;
+            var maxHeight = currentProject.cellSize * currentProject.numOfCellsY;
+            var maxDimensions = new PointF(maxWidth, maxHeight);
+
+            // remove any path with any node with a coordinate below origin or above the calculated maximum
+            currentProject.shipPaths.RemoveAll((path) =>
+            {
+                foreach (var node in path.Nodes)
+                {
+                    if (node.worldX < 0 || node.worldX > maxDimensions.X || node.worldY < 0 ||
+                        node.worldY > maxDimensions.Y)
+                    {
+                        invalidCount++;
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+
+            if (invalidCount > 0)
+            {
+                MessageBox.Show($"Found and removed {invalidCount} invalid paths!", "Invalid Paths Culled", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            else
+            {
+                MessageBox.Show("Did not find any invalid paths to cull!", "No Invalid Paths", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
     }
 
     public class Config


### PR DESCRIPTION
Not sure if this will be useful moving forward, but since I know it was a problem in the recent past - this PR adds a menu item that checks each *node in each* ship path against minimum (0) and maximum (calculated based on grid size) values and removes any that do not fall within these bounds. It then reports to the user what it did via `MessageBox.Show`.