### PR TITLE
Set AcceptButton and CancelButton for forms that have those controls

### DIFF
--- a/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
@@ -156,6 +156,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(415, 565);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(118, 32);
@@ -187,6 +188,7 @@
             // 
             // addSublevels
             // 
+            this.addSublevels.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.addSublevels.Location = new System.Drawing.Point(96, 295);
             this.addSublevels.Name = "addSublevels";
             this.addSublevels.Size = new System.Drawing.Size(90, 24);
@@ -365,8 +367,10 @@
             // 
             // CreateIslndForm
             // 
+            this.AcceptButton = this.createBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(609, 619);
             this.Controls.Add(this.instancesListBox);
             this.Controls.Add(this.label12);

--- a/Src/ServerGridEditor/Forms/CreateProjectForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/CreateProjectForm.Designer.cs
@@ -192,6 +192,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(340, 717);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(83, 32);
@@ -879,8 +880,10 @@
             // 
             // CreateProjectForm
             // 
+            this.AcceptButton = this.createBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(702, 766);
             this.Controls.Add(this.label11);
             this.Controls.Add(this.columnUTCOffsetTxtBox);

--- a/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
@@ -53,6 +53,7 @@
             // cancelBtn
             // 
             this.cancelBtn.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
             this.cancelBtn.Location = new System.Drawing.Point(512, 489);
             this.cancelBtn.Name = "cancelBtn";
@@ -210,8 +211,10 @@
             // 
             // EditDiscoZonesForm
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(1030, 536);
             this.Controls.Add(this.discoZonesGrid);
             this.Controls.Add(this.cancelBtn);

--- a/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
@@ -49,6 +49,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(119, 238);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(92, 32);
@@ -195,8 +196,10 @@
             // 
             // EditDiscoveryZoneInstance
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(224, 279);
             this.Controls.Add(this.allowSeaCheckbox);
             this.Controls.Add(this.explorerNoteIndexTxt);

--- a/Src/ServerGridEditor/Forms/EditIslandInstance.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditIslandInstance.Designer.cs
@@ -101,6 +101,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(192, 612);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(92, 32);
@@ -255,8 +256,10 @@
             // 
             // EditIslandInstance
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(347, 660);
             this.Controls.Add(this.label10);
             this.Controls.Add(this.instanceTreasureQualityAdditionTxtBox);

--- a/Src/ServerGridEditor/Forms/EditServerForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerForm.Designer.cs
@@ -151,6 +151,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(107, 679);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(96, 32);
@@ -667,8 +668,10 @@
             // 
             // EditServerForm
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(667, 762);
             this.Controls.Add(this.OceanEpicSpawnEntriesOverrideValuesTxtBox);
             this.Controls.Add(this.label31);

--- a/Src/ServerGridEditor/Forms/EditServerTemplate.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerTemplate.Designer.cs
@@ -100,6 +100,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(182, 717);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(96, 32);
@@ -565,8 +566,10 @@
             // 
             // EditServerTemplate
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(667, 770);
             this.Controls.Add(this.OceanEpicSpawnEntriesOverrideValuesTxtBox);
             this.Controls.Add(this.label1);

--- a/Src/ServerGridEditor/Forms/EditShipPath.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditShipPath.Designer.cs
@@ -120,6 +120,7 @@
             // 
             // EditShipPath
             // 
+            this.AcceptButton = this.applyBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(359, 216);

--- a/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
@@ -29,10 +29,10 @@
         private void InitializeComponent()
         {
             this.spawnRegionsGrid = new System.Windows.Forms.DataGridView();
-            this.cancelBtn = new System.Windows.Forms.Button();
-            this.saveBtn = new System.Windows.Forms.Button();
             this.regionName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.regionParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.cancelBtn = new System.Windows.Forms.Button();
+            this.saveBtn = new System.Windows.Forms.Button();
             this.messageLabel = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.spawnRegionsGrid)).BeginInit();
             this.SuspendLayout();
@@ -99,8 +99,10 @@
             // 
             // EditSpawnRegions
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(374, 419);
             this.Controls.Add(this.messageLabel);
             this.Controls.Add(this.cancelBtn);

--- a/Src/ServerGridEditor/Forms/LocksForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/LocksForm.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.lockIslandsChkbox = new System.Windows.Forms.CheckBox();
-            this.button1 = new System.Windows.Forms.Button();
+            this.applyBtn = new System.Windows.Forms.Button();
             this.lockDiscoChckbox = new System.Windows.Forms.CheckBox();
             this.lockShipPathsChckbox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
@@ -46,15 +46,15 @@
             this.lockIslandsChkbox.Text = "Lock Islands";
             this.lockIslandsChkbox.UseVisualStyleBackColor = true;
             // 
-            // button1
+            // applyBtn
             // 
-            this.button1.Location = new System.Drawing.Point(68, 140);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
-            this.button1.TabIndex = 1;
-            this.button1.Text = "Apply";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.applyBtn.Location = new System.Drawing.Point(68, 140);
+            this.applyBtn.Name = "applyBtn";
+            this.applyBtn.Size = new System.Drawing.Size(75, 23);
+            this.applyBtn.TabIndex = 1;
+            this.applyBtn.Text = "Apply";
+            this.applyBtn.UseVisualStyleBackColor = true;
+            this.applyBtn.Click += new System.EventHandler(this.button1_Click);
             // 
             // lockDiscoChckbox
             // 
@@ -82,12 +82,13 @@
             // 
             // LocksForm
             // 
+            this.AcceptButton = this.applyBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(217, 189);
             this.Controls.Add(this.lockShipPathsChckbox);
             this.Controls.Add(this.lockDiscoChckbox);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.applyBtn);
             this.Controls.Add(this.lockIslandsChkbox);
             this.Name = "LocksForm";
             this.ShowIcon = false;
@@ -102,7 +103,7 @@
         #endregion
 
         private System.Windows.Forms.CheckBox lockIslandsChkbox;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button applyBtn;
         private System.Windows.Forms.CheckBox lockDiscoChckbox;
         private System.Windows.Forms.CheckBox lockShipPathsChckbox;
     }

--- a/Src/ServerGridEditor/Forms/SharedLogConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/SharedLogConfigForm.Designer.cs
@@ -52,6 +52,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(274, 362);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(90, 32);
@@ -221,8 +222,10 @@
             // 
             // SharedLogConfigForm
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(472, 417);
             this.Controls.Add(this.snapExpHoursTxtBox);
             this.Controls.Add(this.label13);

--- a/Src/ServerGridEditor/Forms/TravelDataConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/TravelDataConfigForm.Designer.cs
@@ -42,6 +42,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(274, 249);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(90, 32);
@@ -135,8 +136,10 @@
             // 
             // TravelDataConfigForm
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(502, 304);
             this.Controls.Add(this.s3KeyPrefixTxtBox);
             this.Controls.Add(this.httpApiKeyTxtBox);

--- a/Src/ServerGridEditor/Forms/TribeLogConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/TribeLogConfigForm.Designer.cs
@@ -46,6 +46,7 @@
             // 
             // cancelBtn
             // 
+            this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelBtn.Location = new System.Drawing.Point(274, 351);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(90, 32);
@@ -167,8 +168,10 @@
             // 
             // TribeLogConfigForm
             // 
+            this.AcceptButton = this.saveBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelBtn;
             this.ClientSize = new System.Drawing.Size(482, 404);
             this.Controls.Add(this.maxRedisLinesTxtBox);
             this.Controls.Add(this.label10);


### PR DESCRIPTION
This is (hopefully) a straightforward PR that sets the [AcceptButton](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.acceptbutton?view=netframework-4.7.2) and [CancelButton](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.cancelbutton?view=netframework-4.7.2) properties on forms that have a pertinent button. I also renamed `button1` to `applyBtn` in `LocksForm.Designer.cs`.

EDIT: The practical purpose of this is enabling the Enter and Escape keys to trigger the Save/Apply and Close/Cancel buttons.