### PR TITLE
Fix for CreateProjectForm MapImageUrl not accepting empty values

### DIFF
--- a/Src/ServerGridEditor/Forms/CreateProjectForm.cs
+++ b/Src/ServerGridEditor/Forms/CreateProjectForm.cs
@@ -187,7 +187,7 @@ namespace ServerGridEditor
                 editedProject.WorldFriendlyName = worldFriendlyNameTxtBox.Text;
                 editedProject.WorldAtlasId = worldAtlasIdTxtBox.Text;
                 editedProject.WorldAtlasPassword = worldAtlasPasswordTxtBox.Text;
-                if (mapImageURLTxtBox.Text != "")
+                if (mapImageURLTxtBox?.Text != null)
                     editedProject.MapImageURL = mapImageURLTxtBox.Text;
 
                 editedProject.MetaWorldURL = metaWorldURLTxtBox.Text;


### PR DESCRIPTION
Fixed issue in CreateProjectForm CreateBtn_Click where MapImageUrl was not being saved when set to a blank value. Applies to issue #30 