### PR TITLE
WinForms cleanup, fix #38

### DIFF
--- a/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace ServerGridEditor
 {
-    partial class CreateIslndForm
+    partial class CreateIslandForm
     {
         /// <summary>
         /// Required designer variable.
@@ -365,7 +365,7 @@
             this.instancesListBox.Size = new System.Drawing.Size(194, 95);
             this.instancesListBox.TabIndex = 39;
             // 
-            // CreateIslndForm
+            // CreateIslandForm
             // 
             this.AcceptButton = this.createBtn;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -404,7 +404,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.islandNameTxtBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Name = "CreateIslndForm";
+            this.Name = "CreateIslandForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Create Island";
             this.Load += new System.EventHandler(this.Form2_Load);

--- a/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/CreateIslandForm.Designer.cs
@@ -404,7 +404,10 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.islandNameTxtBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "CreateIslandForm";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Create Island";
             this.Load += new System.EventHandler(this.Form2_Load);

--- a/Src/ServerGridEditor/Forms/CreateIslandForm.cs
+++ b/Src/ServerGridEditor/Forms/CreateIslandForm.cs
@@ -12,13 +12,13 @@ using System.Windows.Forms;
 
 namespace ServerGridEditor
 {
-    public partial class CreateIslndForm : Form
+    public partial class CreateIslandForm : Form
     {
         public MainForm mainForm;
         public Island editedIsland;
         
         public bool bIslandNameChanged = false;
-        public CreateIslndForm()
+        public CreateIslandForm()
         {
             InitializeComponent();
             pictureBox1.SizeMode = PictureBoxSizeMode.Zoom;

--- a/Src/ServerGridEditor/Forms/CreateIslandForm.resx
+++ b/Src/ServerGridEditor/Forms/CreateIslandForm.resx
@@ -126,12 +126,6 @@
   <metadata name="SpawnerTemplate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SpawnerName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SpawnerTemplate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>45</value>
   </metadata>

--- a/Src/ServerGridEditor/Forms/CreateProjectForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/CreateProjectForm.Designer.cs
@@ -975,7 +975,10 @@
             this.Controls.Add(this.sizeXTxtBox);
             this.Controls.Add(this.label1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "CreateProjectForm";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Create Project";
             this.Load += new System.EventHandler(this.CreateProjectForm_Load);

--- a/Src/ServerGridEditor/Forms/CreateProjectForm.cs
+++ b/Src/ServerGridEditor/Forms/CreateProjectForm.cs
@@ -428,6 +428,7 @@ namespace ServerGridEditor
                 mainForm.currentProject.TravelDataConfig.CopyFrom(TravelDataConfig);
                 mainForm.currentProject.SharedLogConfig.CopyFrom(SharedLogConfig);
             }
+            mainForm.EnableProjectMenuItems();
             Close();
         }
 

--- a/Src/ServerGridEditor/Forms/EditAllLocksForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditAllLocksForm.Designer.cs
@@ -146,8 +146,12 @@
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditAllLocksForm";
             this.ShowIcon = false;
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Locks";
             this.ResumeLayout(false);

--- a/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
@@ -223,9 +223,9 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditDiscoZonesForm";
-            this.Text = "EditDiscoZonesForm";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Edit Discovery Zones";
             ((System.ComponentModel.ISupportInitialize)(this.discoZonesGrid)).EndInit();
             this.ResumeLayout(false);
 

--- a/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoZonesForm.Designer.cs
@@ -219,8 +219,13 @@
             this.Controls.Add(this.discoZonesGrid);
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.saveBtn);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditDiscoZonesForm";
             this.Text = "EditDiscoZonesForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             ((System.ComponentModel.ISupportInitialize)(this.discoZonesGrid)).EndInit();
             this.ResumeLayout(false);
 

--- a/Src/ServerGridEditor/Forms/EditDiscoZonesForm.resx
+++ b/Src/ServerGridEditor/Forms/EditDiscoZonesForm.resx
@@ -159,4 +159,46 @@
   <metadata name="allowSea.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="IsManual.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneManualName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneId.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneParent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneSizeX.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneSizeY.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneSizeZ.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneRotation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="zoneXP.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="LocX.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="LocY.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ExplorerNoteIndex.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="allowSea.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
@@ -218,8 +218,13 @@
             this.Controls.Add(this.zoneNameTxt);
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.saveBtn);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditDiscoveryZoneInstance";
             this.Text = "EditDiscoveryZoneInstance";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditDiscoveryZoneInstance.Designer.cs
@@ -222,9 +222,9 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditDiscoveryZoneInstance";
-            this.Text = "EditDiscoveryZoneInstance";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Edit Discovery Zone Instance";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Src/ServerGridEditor/Forms/EditIslandInstance.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditIslandInstance.Designer.cs
@@ -283,6 +283,7 @@
             this.Controls.Add(this.saveBtn);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.spawnerOverridesGrid);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditIslandInstance";

--- a/Src/ServerGridEditor/Forms/EditIslandInstance.resx
+++ b/Src/ServerGridEditor/Forms/EditIslandInstance.resx
@@ -123,4 +123,10 @@
   <metadata name="SpawnerTemplate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="SpawnerName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SpawnerTemplate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/Src/ServerGridEditor/Forms/EditServerForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerForm.Designer.cs
@@ -741,7 +741,10 @@
             this.Controls.Add(this.portTxtBox);
             this.Controls.Add(this.label1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditServerForm";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Edit Server";
             this.Load += new System.EventHandler(this.EditServerForm_Load);

--- a/Src/ServerGridEditor/Forms/EditServerTemplate.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerTemplate.Designer.cs
@@ -629,7 +629,10 @@
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.saveBtn);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditServerTemplate";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Edit Server Template";
             this.Load += new System.EventHandler(this.EditServerTemplate_Load);

--- a/Src/ServerGridEditor/Forms/EditServerTemplates.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerTemplates.Designer.cs
@@ -89,7 +89,7 @@
             this.Name = "EditServerTemplates";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "EditServerTemplates";
+            this.Text = "Edit Server Templates";
             this.ResumeLayout(false);
 
         }

--- a/Src/ServerGridEditor/Forms/EditServerTemplates.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditServerTemplates.Designer.cs
@@ -84,7 +84,10 @@
             this.Controls.Add(this.addBtn);
             this.Controls.Add(this.templatesLstBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditServerTemplates";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "EditServerTemplates";
             this.ResumeLayout(false);

--- a/Src/ServerGridEditor/Forms/EditServerTemplates.cs
+++ b/Src/ServerGridEditor/Forms/EditServerTemplates.cs
@@ -65,9 +65,9 @@ namespace ServerGridEditor.Forms
                 {
                     var confirmResult = MessageBox.Show("You are about to delete the selected template\n\nAre you sure?",
                                             "Warning",
-                                            MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                                            MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-                    if (confirmResult == DialogResult.OK)
+                    if (confirmResult == DialogResult.Yes)
                     {
                         templatesLstBox.Items.Remove(serverTemplate.name);
                         mainForm.currentProject.serverTemplates.Remove(serverTemplate);

--- a/Src/ServerGridEditor/Forms/EditShipPath.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditShipPath.Designer.cs
@@ -133,8 +133,12 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.applyBtn);
             this.Controls.Add(this.loopingPathChckBox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditShipPath";
             this.ShowIcon = false;
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Edit Ship Path";
             this.Load += new System.EventHandler(this.EditShipPath_Load);

--- a/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
@@ -108,8 +108,12 @@
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.saveBtn);
             this.Controls.Add(this.spawnRegionsGrid);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "EditSpawnRegions";
             this.Text = "EditSpawnRegions";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             ((System.ComponentModel.ISupportInitialize)(this.spawnRegionsGrid)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
+++ b/Src/ServerGridEditor/Forms/EditSpawnRegions.Designer.cs
@@ -112,8 +112,8 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditSpawnRegions";
-            this.Text = "EditSpawnRegions";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Edit Spawn Regions";
             ((System.ComponentModel.ISupportInitialize)(this.spawnRegionsGrid)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/Src/ServerGridEditor/Forms/LocksForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/LocksForm.Designer.cs
@@ -90,8 +90,12 @@
             this.Controls.Add(this.lockDiscoChckbox);
             this.Controls.Add(this.applyBtn);
             this.Controls.Add(this.lockIslandsChkbox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "LocksForm";
             this.ShowIcon = false;
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Locks";
             this.Load += new System.EventHandler(this.LocksForm_Load);

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -1596,7 +1596,7 @@ namespace ServerGridEditor
         {
             if (currentProject != null)
             {
-                MessageBox.Show("Creating a project will overwrite the currently opened one");
+                MessageBox.Show("If you create a new project, any unsaved changes to your current project will be LOST!");
             }
 
             var createForm = new CreateProjectForm();
@@ -1623,12 +1623,11 @@ namespace ServerGridEditor
         {
             if (currentProject != null)
             {
-                var confirmResult = MessageBox.Show("Opening a project will overwrite the currently opened one, open?",
+                var confirmResult = MessageBox.Show("If you click OK, any unsaved changes to your current project will be LOST!",
                                      "Warning",
                                      MessageBoxButtons.OKCancel);
                 if (confirmResult != DialogResult.OK)
                     return;
-                //MessageBox.Show("Opening a project will overwrite the currently opened one");
             }
 
             openFileDialog.Filter = "json files (*.json)|*.json";
@@ -1750,7 +1749,7 @@ namespace ServerGridEditor
 
         private void removeIslandBtn_Click(object sender, EventArgs e)
         {
-            var confirmResult = MessageBox.Show("Removing an island will remove all its instances in the map\nAre you sure?",
+            var confirmResult = MessageBox.Show("Removing an island will remove all its instances in the map!\n\nAre you sure?",
                                     "Warning",
                                     MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
 
@@ -1964,7 +1963,7 @@ namespace ServerGridEditor
         {
             if (currentProject != null)
             {
-                var confirmResult = MessageBox.Show("All unsaved progress will be lost", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Exclamation);
+                var confirmResult = MessageBox.Show("All unsaved changes to your current project will be LOST!", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Exclamation);
                 if (confirmResult == DialogResult.Cancel)
                     e.Cancel = true;
             }
@@ -1985,7 +1984,7 @@ namespace ServerGridEditor
         {
             if (currentProject != null)
             {
-                MessageBox.Show("Creating a project will overwrite the currently opened one");
+                MessageBox.Show("If you create a new project, any unsaved changes to your current project will be LOST!");
             }
 
             var createForm = new CreateProjectForm();

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -1561,7 +1561,7 @@ namespace ServerGridEditor
         ///////////////////////////Action Handlers///////////////////////////////////
         private void addIslandBtn_Click(object sender, EventArgs e)
         {
-            var createForm = new CreateIslndForm();
+            var createForm = new CreateIslandForm();
             createForm.mainForm = this;
             createForm.ShowDialog();
         }
@@ -1840,7 +1840,7 @@ namespace ServerGridEditor
             if (isle == null)
                 return;
 
-            var createForm = new CreateIslndForm();
+            var createForm = new CreateIslandForm();
             createForm.mainForm = this;
             createForm.editedIsland = isle;
             if(createForm.ShowDialog() != DialogResult.Cancel && createForm.bIslandNameChanged)

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -1751,45 +1751,42 @@ namespace ServerGridEditor
         {
             var confirmResult = MessageBox.Show("Removing an island will remove all its instances in the map!\n\nAre you sure?",
                                     "Warning",
-                                    MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                                    MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-            if (confirmResult == DialogResult.OK)
+            if (confirmResult != DialogResult.Yes)
+                return;
+
+            List<string> islandsToRemove = new List<string>();
+
+            foreach (ListViewItem item in islandListBox.SelectedItems)
             {
-
-                List<string> islandsToRemove = new List<string>();
-
-                foreach (ListViewItem item in islandListBox.SelectedItems)
-                {
-                    islandsToRemove.Add(item.SubItems[2].Text);
-                }
-
-                if (currentProject != null)
-                {
-                    for (int i = 0; i < currentProject.islandInstances.Count; i++)
-                        foreach (string islandToRemove in islandsToRemove)
-                            if (currentProject.islandInstances[i].name == islandToRemove)
-                            {
-                                currentProject.islandInstances[i].SetDirty(this);
-                                currentProject.islandInstances.RemoveAt(i);
-                                i--;
-                            }
-                }
-
-                foreach (string islandToRemove in islandsToRemove)
-                {
-                    //delete the image
-                    islands[islandToRemove].InvalidateImage();
-                    File.Delete(islands[islandToRemove].imagePath);
-
-                    islands.Remove(islandToRemove);
-                }
-
-
-                RefreshIslandList();
-                mapPanel.Invalidate();
-                SaveIslands();
+                islandsToRemove.Add(item.SubItems[2].Text);
             }
 
+            if (currentProject != null)
+            {
+                for (int i = 0; i < currentProject.islandInstances.Count; i++)
+                    foreach (string islandToRemove in islandsToRemove)
+                        if (currentProject.islandInstances[i].name == islandToRemove)
+                        {
+                            currentProject.islandInstances[i].SetDirty(this);
+                            currentProject.islandInstances.RemoveAt(i);
+                            i--;
+                        }
+            }
+
+            foreach (string islandToRemove in islandsToRemove)
+            {
+                //delete the image
+                islands[islandToRemove].InvalidateImage();
+                File.Delete(islands[islandToRemove].imagePath);
+
+                islands.Remove(islandToRemove);
+            }
+
+            RefreshIslandList();
+            mapPanel.Invalidate();
+            SaveIslands();
         }
 
         private void showServerInfoCheckbox_CheckedChanged(object sender, EventArgs e)
@@ -1964,8 +1961,7 @@ namespace ServerGridEditor
             if (currentProject != null)
             {
                 var confirmResult = MessageBox.Show("All unsaved changes to your current project will be LOST!", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Exclamation);
-                if (confirmResult == DialogResult.Cancel)
-                    e.Cancel = true;
+                e.Cancel = confirmResult == DialogResult.Cancel;
             }
         }
 

--- a/Src/ServerGridEditor/Forms/SharedLogConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/SharedLogConfigForm.Designer.cs
@@ -248,7 +248,11 @@
             this.Controls.Add(this.saveBtn);
             this.Controls.Add(this.cancelBtn);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "SharedLogConfigForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Shared Log Config";
             this.Load += new System.EventHandler(this.SharedLogConfigForm_Load);
             this.ResumeLayout(false);

--- a/Src/ServerGridEditor/Forms/TravelDataConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/TravelDataConfigForm.Designer.cs
@@ -152,7 +152,11 @@
             this.Controls.Add(this.saveBtn);
             this.Controls.Add(this.cancelBtn);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "TravelDataConfigForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Travel Data Config";
             this.Load += new System.EventHandler(this.TravelDataConfigForm_Load);
             this.ResumeLayout(false);

--- a/Src/ServerGridEditor/Forms/TribeLogConfigForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/TribeLogConfigForm.Designer.cs
@@ -188,7 +188,11 @@
             this.Controls.Add(this.saveBtn);
             this.Controls.Add(this.cancelBtn);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "TribeLogConfigForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Tribe Log Config";
             this.Load += new System.EventHandler(this.TribeLogConfigForm_Load);
             this.ResumeLayout(false);


### PR DESCRIPTION
Summary of changes:

* Refactor `CreateIslndForm` to `CreateIslandForm`
* Set MinimizeBox, MaximizeBox, and ShowInTaskbar to false for dialog forms
* Set FormBorderStyle to FixedDialog for dialog forms
* Add missing spaces to form Text properties (e.g. `EditServerTemplates` to `Edit Server Templates`)
* Rewrite several of the warning/confirmation dialogs to be more explicit and consistent in verbiage

EDIT: This PR also fixes #38.

Please let me know if you have any questions or requested changes.