### PR TITLE
Add dialog for customizing slippy map export

### DIFF
--- a/Src/ServerGridEditor/Forms/ExportSlippyMap.Designer.cs
+++ b/Src/ServerGridEditor/Forms/ExportSlippyMap.Designer.cs
@@ -1,0 +1,201 @@
+﻿namespace ServerGridEditor.Forms
+{
+    partial class ExportSlippyMap
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.maxZoomTrackBar = new System.Windows.Forms.TrackBar();
+            this.maxZoomLabel = new System.Windows.Forms.Label();
+            this.maxZoomMaxLabel = new System.Windows.Forms.Label();
+            this.maxZoomMinLabel = new System.Windows.Forms.Label();
+            this.exportButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.tileCountLabel = new System.Windows.Forms.Label();
+            this.exportDirBrowseButton = new System.Windows.Forms.Button();
+            this.exportDirTextBox = new System.Windows.Forms.TextBox();
+            this.exportDirLabel = new System.Windows.Forms.Label();
+            this.overwriteCheckBox = new System.Windows.Forms.CheckBox();
+            ((System.ComponentModel.ISupportInitialize)(this.maxZoomTrackBar)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // maxZoomTrackBar
+            // 
+            this.maxZoomTrackBar.LargeChange = 2;
+            this.maxZoomTrackBar.Location = new System.Drawing.Point(78, 12);
+            this.maxZoomTrackBar.Maximum = 6;
+            this.maxZoomTrackBar.Minimum = 2;
+            this.maxZoomTrackBar.Name = "maxZoomTrackBar";
+            this.maxZoomTrackBar.Size = new System.Drawing.Size(222, 45);
+            this.maxZoomTrackBar.TabIndex = 0;
+            this.maxZoomTrackBar.Value = 6;
+            this.maxZoomTrackBar.ValueChanged += new System.EventHandler(this.maxZoomTrackBar_ValueChanged);
+            // 
+            // maxZoomLabel
+            // 
+            this.maxZoomLabel.AutoSize = true;
+            this.maxZoomLabel.Location = new System.Drawing.Point(12, 28);
+            this.maxZoomLabel.Name = "maxZoomLabel";
+            this.maxZoomLabel.Size = new System.Drawing.Size(60, 13);
+            this.maxZoomLabel.TabIndex = 1;
+            this.maxZoomLabel.Text = "Max. Zoom";
+            // 
+            // maxZoomMaxLabel
+            // 
+            this.maxZoomMaxLabel.AutoSize = true;
+            this.maxZoomMaxLabel.Location = new System.Drawing.Point(279, 56);
+            this.maxZoomMaxLabel.Name = "maxZoomMaxLabel";
+            this.maxZoomMaxLabel.Size = new System.Drawing.Size(13, 13);
+            this.maxZoomMaxLabel.TabIndex = 2;
+            this.maxZoomMaxLabel.Text = "6";
+            this.maxZoomMaxLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // maxZoomMinLabel
+            // 
+            this.maxZoomMinLabel.AutoSize = true;
+            this.maxZoomMinLabel.Location = new System.Drawing.Point(84, 56);
+            this.maxZoomMinLabel.Name = "maxZoomMinLabel";
+            this.maxZoomMinLabel.Size = new System.Drawing.Size(13, 13);
+            this.maxZoomMinLabel.TabIndex = 3;
+            this.maxZoomMinLabel.Text = "2";
+            this.maxZoomMinLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // exportButton
+            // 
+            this.exportButton.Location = new System.Drawing.Point(144, 105);
+            this.exportButton.Name = "exportButton";
+            this.exportButton.Size = new System.Drawing.Size(75, 23);
+            this.exportButton.TabIndex = 4;
+            this.exportButton.Text = "Export";
+            this.exportButton.UseVisualStyleBackColor = true;
+            this.exportButton.Click += new System.EventHandler(this.exportButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(225, 105);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 5;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            // 
+            // tileCountLabel
+            // 
+            this.tileCountLabel.Location = new System.Drawing.Point(103, 56);
+            this.tileCountLabel.Name = "tileCountLabel";
+            this.tileCountLabel.Size = new System.Drawing.Size(169, 13);
+            this.tileCountLabel.TabIndex = 6;
+            this.tileCountLabel.Text = "0 tiles";
+            this.tileCountLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // exportDirBrowseButton
+            // 
+            this.exportDirBrowseButton.Location = new System.Drawing.Point(270, 76);
+            this.exportDirBrowseButton.Name = "exportDirBrowseButton";
+            this.exportDirBrowseButton.Size = new System.Drawing.Size(30, 23);
+            this.exportDirBrowseButton.TabIndex = 7;
+            this.exportDirBrowseButton.Text = "...";
+            this.exportDirBrowseButton.UseVisualStyleBackColor = true;
+            this.exportDirBrowseButton.Click += new System.EventHandler(this.exportDirBrowseButton_Click);
+            // 
+            // exportDirTextBox
+            // 
+            this.exportDirTextBox.Location = new System.Drawing.Point(78, 78);
+            this.exportDirTextBox.Name = "exportDirTextBox";
+            this.exportDirTextBox.Size = new System.Drawing.Size(186, 20);
+            this.exportDirTextBox.TabIndex = 8;
+            // 
+            // exportDirLabel
+            // 
+            this.exportDirLabel.AutoSize = true;
+            this.exportDirLabel.Location = new System.Drawing.Point(12, 81);
+            this.exportDirLabel.Name = "exportDirLabel";
+            this.exportDirLabel.Size = new System.Drawing.Size(52, 13);
+            this.exportDirLabel.TabIndex = 9;
+            this.exportDirLabel.Text = "Directory:";
+            // 
+            // overwriteCheckBox
+            // 
+            this.overwriteCheckBox.AutoSize = true;
+            this.overwriteCheckBox.Checked = true;
+            this.overwriteCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.overwriteCheckBox.Location = new System.Drawing.Point(12, 109);
+            this.overwriteCheckBox.Name = "overwriteCheckBox";
+            this.overwriteCheckBox.Size = new System.Drawing.Size(71, 17);
+            this.overwriteCheckBox.TabIndex = 10;
+            this.overwriteCheckBox.Text = "Overwrite";
+            this.overwriteCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // ExportSlippyMap
+            // 
+            this.AcceptButton = this.exportButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(309, 136);
+            this.Controls.Add(this.overwriteCheckBox);
+            this.Controls.Add(this.exportDirLabel);
+            this.Controls.Add(this.exportDirTextBox);
+            this.Controls.Add(this.exportDirBrowseButton);
+            this.Controls.Add(this.tileCountLabel);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.exportButton);
+            this.Controls.Add(this.maxZoomMinLabel);
+            this.Controls.Add(this.maxZoomMaxLabel);
+            this.Controls.Add(this.maxZoomLabel);
+            this.Controls.Add(this.maxZoomTrackBar);
+            this.MaximizeBox = false;
+            this.MaximumSize = new System.Drawing.Size(325, 175);
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(325, 175);
+            this.Name = "ExportSlippyMap";
+            this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Export Slippy Map";
+            ((System.ComponentModel.ISupportInitialize)(this.maxZoomTrackBar)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TrackBar maxZoomTrackBar;
+        private System.Windows.Forms.Label maxZoomLabel;
+        private System.Windows.Forms.Label maxZoomMaxLabel;
+        private System.Windows.Forms.Label maxZoomMinLabel;
+        private System.Windows.Forms.Button exportButton;
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Label tileCountLabel;
+        private System.Windows.Forms.Button exportDirBrowseButton;
+        private System.Windows.Forms.TextBox exportDirTextBox;
+        private System.Windows.Forms.Label exportDirLabel;
+        private System.Windows.Forms.CheckBox overwriteCheckBox;
+    }
+}

--- a/Src/ServerGridEditor/Forms/ExportSlippyMap.Designer.cs
+++ b/Src/ServerGridEditor/Forms/ExportSlippyMap.Designer.cs
@@ -174,6 +174,7 @@
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(325, 175);
             this.Name = "ExportSlippyMap";
+            this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/Src/ServerGridEditor/Forms/ExportSlippyMap.cs
+++ b/Src/ServerGridEditor/Forms/ExportSlippyMap.cs
@@ -1,0 +1,91 @@
+﻿using ServerGridEditor.Code;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ServerGridEditor.Forms
+{
+    public partial class ExportSlippyMap : Form
+    {
+        /// <summary>
+        /// The tile image filesize varies based on zoom level, water background, and other factors.
+        /// This value gives +-10% accuracy estimates for the projects that are included with the solution.
+        /// </summary>
+        private static readonly double AverageImageSizeMb = 0.05d;
+
+        /// <summary>
+        /// The currently selected maximum zoom level for the map. Values can range from 2 to 9.
+        /// </summary>
+        public int MaxZoom => maxZoomTrackBar.Value;
+
+        /// <summary>
+        /// The currently selected export directory for the map.
+        /// </summary>
+        public string ExportDirectory => exportDirTextBox.Text;
+
+        /// <summary>
+        /// If false, skip any tile where the file already exists.
+        /// </summary>
+        public bool OverwriteExisting => overwriteCheckBox.Checked;
+
+        public ExportSlippyMap()
+        {
+            InitializeComponent();
+            maxZoomTrackBar_ValueChanged(maxZoomTrackBar, EventArgs.Empty);
+        }
+
+        private void maxZoomTrackBar_ValueChanged(object sender, EventArgs e)
+        {
+            var tileCount = Enumerable
+                .Range(0, MaxZoom + 1)
+                .Aggregate(0, (accum, curr) =>
+                    accum + (int)Math.Ceiling(Math.Pow(4, curr))
+                );
+            var estimatedSizeMb = Math.Round(AverageImageSizeMb * tileCount, 2);
+            tileCountLabel.Text = $"{tileCount} tiles (~{estimatedSizeMb} MB)";
+        }
+
+        private void exportButton_Click(object sender, EventArgs e)
+        {
+            if (!Directory.Exists(ExportDirectory))
+            {
+                MessageBox.Show($"The path \"{ExportDirectory}\" does not exist!", "Invalid Path", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void cancelButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+
+        private void exportDirBrowseButton_Click(object sender, EventArgs e)
+        {
+            using (var browser = new FolderBrowserDialog())
+            {
+                if (browser.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(browser.SelectedPath))
+                {
+                    MessageBox.Show("Empty path supplied!", "Browse Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+
+                exportDirTextBox.Text = browser.SelectedPath;
+            }
+        }
+    }
+}

--- a/Src/ServerGridEditor/Forms/ExportSlippyMap.resx
+++ b/Src/ServerGridEditor/Forms/ExportSlippyMap.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Src/ServerGridEditor/Forms/MainForm.Designer.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.Designer.cs
@@ -52,11 +52,12 @@
             this.editSpawnPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editServerTemplatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editLocksToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cullInvalidPathsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.localExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.exportAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mapImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cellImagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.slippyMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testAllServersWithDataClearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -92,7 +93,6 @@
             this.foregroundScaleBox = new System.Windows.Forms.NumericUpDown();
             this.label5 = new System.Windows.Forms.Label();
             this.atlasLocation = new System.Windows.Forms.Label();
-            this.cullInvalidPathsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tileScaleBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.foregroundScaleBox)).BeginInit();
@@ -323,53 +323,60 @@
             this.editLocksToolStripMenuItem.Text = "Edit Locks";
             this.editLocksToolStripMenuItem.Click += new System.EventHandler(this.editLocksToolStripMenuItem_Click);
             // 
+            // cullInvalidPathsToolStripMenuItem
+            // 
+            this.cullInvalidPathsToolStripMenuItem.Name = "cullInvalidPathsToolStripMenuItem";
+            this.cullInvalidPathsToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.cullInvalidPathsToolStripMenuItem.Text = "Cull Invalid Paths";
+            this.cullInvalidPathsToolStripMenuItem.Click += new System.EventHandler(this.cullInvalidPathsToolStripMenuItem_Click);
+            // 
             // exportToolStripMenuItem
             // 
             this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.localExportToolStripMenuItem,
-            this.toolStripSeparator1,
+            this.exportAllToolStripMenuItem,
             this.mapImageToolStripMenuItem,
             this.cellImagesToolStripMenuItem,
+            this.toolStripSeparator1,
             this.slippyMapToolStripMenuItem});
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
             this.exportToolStripMenuItem.Text = "Export";
             // 
-            // localExportToolStripMenuItem
+            // exportAllToolStripMenuItem
             // 
-            this.localExportToolStripMenuItem.Enabled = false;
-            this.localExportToolStripMenuItem.Name = "localExportToolStripMenuItem";
-            this.localExportToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
-            this.localExportToolStripMenuItem.Text = "Local Export All";
-            this.localExportToolStripMenuItem.Click += new System.EventHandler(this.localExportToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(268, 6);
+            this.exportAllToolStripMenuItem.Enabled = false;
+            this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.exportAllToolStripMenuItem.Text = "All";
+            this.exportAllToolStripMenuItem.Click += new System.EventHandler(this.localExportToolStripMenuItem_Click);
             // 
             // mapImageToolStripMenuItem
             // 
             this.mapImageToolStripMenuItem.Enabled = false;
             this.mapImageToolStripMenuItem.Name = "mapImageToolStripMenuItem";
-            this.mapImageToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
-            this.mapImageToolStripMenuItem.Text = "Export: Just Map Image";
+            this.mapImageToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.mapImageToolStripMenuItem.Text = "Only Map Image";
             this.mapImageToolStripMenuItem.Click += new System.EventHandler(this.mapImageToolStripMenuItem_Click);
             // 
             // cellImagesToolStripMenuItem
             // 
             this.cellImagesToolStripMenuItem.Enabled = false;
             this.cellImagesToolStripMenuItem.Name = "cellImagesToolStripMenuItem";
-            this.cellImagesToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
-            this.cellImagesToolStripMenuItem.Text = "Export : Just Cell Images";
+            this.cellImagesToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.cellImagesToolStripMenuItem.Text = "Only Cell Images";
             this.cellImagesToolStripMenuItem.Click += new System.EventHandler(this.cellImagesToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(187, 6);
             // 
             // slippyMapToolStripMenuItem
             // 
             this.slippyMapToolStripMenuItem.Enabled = false;
             this.slippyMapToolStripMenuItem.Name = "slippyMapToolStripMenuItem";
-            this.slippyMapToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
-            this.slippyMapToolStripMenuItem.Text = "Generate Slippy Map (Optional Tools)";
+            this.slippyMapToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.slippyMapToolStripMenuItem.Text = "Slippy Map (Optional)";
             this.slippyMapToolStripMenuItem.Click += new System.EventHandler(this.slippyMapToolStripMenuItem_Click);
             // 
             // testsToolStripMenuItem
@@ -762,13 +769,6 @@
             this.atlasLocation.TabIndex = 36;
             this.atlasLocation.Text = "Atlas Location";
             // 
-            // cullInvalidPathsToolStripMenuItem
-            // 
-            this.cullInvalidPathsToolStripMenuItem.Name = "cullInvalidPathsToolStripMenuItem";
-            this.cullInvalidPathsToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
-            this.cullInvalidPathsToolStripMenuItem.Text = "Cull Invalid Paths";
-            this.cullInvalidPathsToolStripMenuItem.Click += new System.EventHandler(this.cullInvalidPathsToolStripMenuItem_Click);
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -877,7 +877,7 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox cellImageSizetxtbox;
         private System.Windows.Forms.ToolStripMenuItem slippyMapToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem localExportToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportAllToolStripMenuItem;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TextBox atlasImageSizeTxtBox;
         private System.Windows.Forms.Button chooseDiscoZoneBtn;
@@ -895,8 +895,8 @@
         private System.Windows.Forms.Label atlasLocation;
         private System.Windows.Forms.ToolStripMenuItem editServerTemplatesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editLocksToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem cullInvalidPathsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
     }
 }
 

--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -185,7 +185,7 @@ namespace ServerGridEditor
             mapImageToolStripMenuItem.Enabled = true;
             slippyMapToolStripMenuItem.Enabled = true;
             cellImagesToolStripMenuItem.Enabled = true;
-            localExportToolStripMenuItem.Enabled = true;
+            exportAllToolStripMenuItem.Enabled = true;
             editServerTemplatesToolStripMenuItem.Enabled = true;
             testAllServersWithoutDataClearToolStripMenuItem.Enabled = true;
         }
@@ -2092,45 +2092,38 @@ namespace ServerGridEditor
             if (currentProject == null)
                 return;
 
-            string outpath;
-            using (var win = new FolderBrowserDialog())
+            using (var exportMapForm = new ExportSlippyMap())
             {
-                var result = win.ShowDialog(this);
-                if (result != DialogResult.OK)
+                if (exportMapForm.ShowDialog() != DialogResult.OK)
                     return;
 
-                outpath = win.SelectedPath;
-            }
-
-            if (string.IsNullOrWhiteSpace(outpath))
-                return;
-
-            try
-            {
-                using (var progressForm = new ProgressForm())
+                try
                 {
-                    progressForm.Initialize(SlippyMap.maximumZoomLevel + 2, "Starting...");
-                    progressForm.Show();
+                    using (var progressForm = new ProgressForm())
+                    {
+                        progressForm.Initialize(exportMapForm.MaxZoom + 2, "Starting...");
+                        progressForm.Show();
 
-                    this.ExportSlippyMap(
-                        islands, showLinesCheckbox.Checked, showServerInfoCheckbox.Checked, showDiscoZoneInfoCheckbox.Checked,
-                        tile, tileBrush, mapPanel.BackColor, outpath,
-                        (string text) =>
-                        {
-                            Console.WriteLine(text);
-                            progressForm.NextStep(text);
-                        });
+                        this.ExportSlippyMap(
+                            islands, showLinesCheckbox.Checked, showServerInfoCheckbox.Checked, showDiscoZoneInfoCheckbox.Checked,
+                            tile, tileBrush, mapPanel.BackColor, exportMapForm.ExportDirectory,
+                            (string text) =>
+                            {
+                                Console.WriteLine(text);
+                                progressForm.NextStep(text);
+                            }, exportMapForm.MaxZoom, exportMapForm.OverwriteExisting);
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, "Export Failed",
-                    MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
-            }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Export Failed",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
 
-            MessageBox.Show("Slippy Map exported.", "Slippy Map Exported",
-                MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show("Slippy Map exported.", "Slippy Map Exported",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
 
         private void localExportToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Src/ServerGridEditor/ServerGridEditor.csproj
+++ b/Src/ServerGridEditor/ServerGridEditor.csproj
@@ -114,6 +114,12 @@
     <Compile Include="Forms\EditAllLocksForm.Designer.cs">
       <DependentUpon>EditAllLocksForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\ExportSlippyMap.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\ExportSlippyMap.Designer.cs">
+      <DependentUpon>ExportSlippyMap.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\SharedLogConfigForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -219,6 +225,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\EditAllLocksForm.resx">
       <DependentUpon>EditAllLocksForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\ExportSlippyMap.resx">
+      <DependentUpon>ExportSlippyMap.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\SharedLogConfigForm.resx">
       <DependentUpon>SharedLogConfigForm.cs</DependentUpon>


### PR DESCRIPTION
This PR changes the Export menu item labels to be a bit more consistent:

![new-menu](https://user-images.githubusercontent.com/266545/50729586-88901580-110a-11e9-9285-ecac55c047d9.PNG)

More importantly, it adds a new dialog that opens when "Slippy Map" is selected from the Export menu.

![new-dialog](https://user-images.githubusercontent.com/266545/50729584-86c65200-110a-11e9-958f-1816e4babc49.PNG)

This dialog lets you set the max zoom, the output directory (using the same `FolderBrowserDialog` as before), and whether or not to skip tiles that already exist in the chosen export directory. It provides an accurate count of the number of tiles that will be generated, and a fairly accurate estimate of the disk size.

Please let me know if you have questions or requested changes.