### PR TITLE
Revised Help Dialog Text for Move, Rotate, and Delete

### DIFF
--- a/Src/ServerGridEditor/Forms/MainForm.cs
+++ b/Src/ServerGridEditor/Forms/MainForm.cs
@@ -1947,10 +1947,10 @@ namespace ServerGridEditor
 
         private void controlsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MessageBox.Show("Hold Left click (Move island)\n" +
-                "Hold Right click (Rotate island)\n" + 
+            MessageBox.Show("Hold Left click (Move)\n" +
+                "Hold Right click (Rotate)\n" + 
                 "Mouse wheel (Zoom)\n" + 
-                "Delete button (Remove island)\n" + 
+                "Delete button (Remove)\n" + 
                 "Ctrl + click on grid (Edit server info)\n" + 
                 "Ctrl + click on island (Edit island info)\n" + 
                 "Hold middle mouse + drag (Scroll map)\n" + 


### PR DESCRIPTION
Revised Help Text Dialog for Move, Rotate, and Delete to make it obvious that these functions apply to more than just islands.

Just a little thing for future people who use the editor. The rotate function on discovery zones was not obvious to me, despite having now built two maps myself (5x8 and 7x7). The help dialog was too specific for me to realize that it also applies to discovery zones, along with the move and delete functions. I discovered this while looking at the discovery zones dialog and seeing the rotation column. Yeah I feel stupid for not realizing this...I want to make sure other people don't miss this.